### PR TITLE
enable configuration of MDB_IDL_LOGN

### DIFF
--- a/libraries/liblmdb/midl.h
+++ b/libraries/liblmdb/midl.h
@@ -56,7 +56,9 @@ typedef MDB_ID *MDB_IDL;
 /* IDL sizes - likely should be even bigger
  *   limiting factors: sizeof(ID), thread stack size
  */
+#ifndef MDB_IDL_LOGN
 #define	MDB_IDL_LOGN	16	/* DB_SIZE is 2^16, UM_SIZE is 2^17 */
+#endif
 #define MDB_IDL_DB_SIZE		(1<<MDB_IDL_LOGN)
 #define MDB_IDL_UM_SIZE		(1<<(MDB_IDL_LOGN+1))
 


### PR DESCRIPTION
@ncloudioj I wonder if we could reduce heap allocations to a reasonable amount when opening an environment in read-write mode in Firefox by decreasing `MDB_IDL_LOGN` (and thus `MDB_IDL_DB_SIZE` and `MDB_IDL_UM_SIZE`). Something like this change would enable configuration of `MDB_IDL_LOGN`, which Firefox (and other apps) could then define when building LMDB.

I'm not sure what we'd set it to. We'd have to determine a value that is low enough to reduce allocations to a reasonable amount while being high enough to support our usage today and in the future. Some testing shows that much lower values pass tests of cert_storage and xulstore usage, although it isn't clear to me that those are representative workloads.

In any case, I'm interested in what you think about the general approach!
