### PR TITLE
return result code from mdb_cursor_init; observe it in mdb_put

### DIFF
--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -1406,7 +1406,7 @@ static int	mdb_cursor_set(MDB_cursor *mc, MDB_val *key, MDB_val *data, MDB_curso
 static int	mdb_cursor_first(MDB_cursor *mc, MDB_val *key, MDB_val *data);
 static int	mdb_cursor_last(MDB_cursor *mc, MDB_val *key, MDB_val *data);
 
-static int 	mdb_cursor_init(MDB_cursor *mc, MDB_txn *txn, MDB_dbi dbi, MDB_xcursor *mx);
+static void	mdb_cursor_init(MDB_cursor *mc, MDB_txn *txn, MDB_dbi dbi, MDB_xcursor *mx);
 static void	mdb_xcursor_init0(MDB_cursor *mc);
 static void	mdb_xcursor_init1(MDB_cursor *mc, MDB_node *node);
 static void	mdb_xcursor_init2(MDB_cursor *mc, MDB_xcursor *src_mx, int force);
@@ -7597,11 +7597,9 @@ mdb_xcursor_init2(MDB_cursor *mc, MDB_xcursor *src_mx, int new_dupdata)
 }
 
 /** Initialize a cursor for a given transaction and database. */
-static int
+static void
 mdb_cursor_init(MDB_cursor *mc, MDB_txn *txn, MDB_dbi dbi, MDB_xcursor *mx)
 {
-	int rc = MDB_SUCCESS;
-
 	mc->mc_next = NULL;
 	mc->mc_backup = NULL;
 	mc->mc_dbi = dbi;
@@ -7622,9 +7620,8 @@ mdb_cursor_init(MDB_cursor *mc, MDB_txn *txn, MDB_dbi dbi, MDB_xcursor *mx)
 		mc->mc_xcursor = NULL;
 	}
 	if (*mc->mc_dbflag & DB_STALE) {
-		rc = mdb_page_search(mc, NULL, MDB_PS_ROOTONLY);
+		mdb_page_search(mc, NULL, MDB_PS_ROOTONLY);
 	}
-	return rc;
 }
 
 int
@@ -9019,10 +9016,7 @@ mdb_put(MDB_txn *txn, MDB_dbi dbi,
 	if (txn->mt_flags & (MDB_TXN_RDONLY|MDB_TXN_BLOCKED))
 		return (txn->mt_flags & MDB_TXN_RDONLY) ? EACCES : MDB_BAD_TXN;
 
-	if ((rc = mdb_cursor_init(&mc, txn, dbi, &mx)) != MDB_SUCCESS) {
-		return rc;
-	}
-
+	mdb_cursor_init(&mc, txn, dbi, &mx);
 	mc.mc_next = txn->mt_cursors[dbi];
 	txn->mt_cursors[dbi] = &mc;
 	rc = mdb_cursor_put(&mc, key, data, flags);

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -7620,7 +7620,8 @@ mdb_cursor_init(MDB_cursor *mc, MDB_txn *txn, MDB_dbi dbi, MDB_xcursor *mx)
 		mc->mc_xcursor = NULL;
 	}
 	if (*mc->mc_dbflag & DB_STALE) {
-		mdb_page_search(mc, NULL, MDB_PS_ROOTONLY);
+		int rc = mdb_page_search(mc, NULL, MDB_PS_ROOTONLY);
+		mdb_cassert(mc, !rc);
 	}
 }
 


### PR DESCRIPTION
@ncloudioj While investigating crasher [bug 1538541](https://bugzilla.mozilla.org/show_bug.cgi?id=1538541), I noticed that `mdb_put` calls `mdb_cursor_init`, which doesn't return a result code.

But `mdb_cursor_init` calls `mdb_page_search`, which can fail. And a stack trace from one of the crashes shows that the null pointer that gets dereferenced, causing the crash, is already null after `mdb_put` calls `mdb_cursor_init`, before it calls `mdb_cursor_put`; and there's no code in `mdb_cursor_put` that sets it before `mdb_cursor_put` tries to dereference it; which means that the crash is guaranteed to occur as soon as `mdb_cursor_init` returns in `mdb_put`.

It still isn't clear to me why the pointer is null, nor why `mdb_cursor_init` doesn't return a result code. But it occurs to me that `mdb_page_search` might be failing, and thus we might be able to avoid the crashes—even if we haven't resolved the underlying failure—by returning a result code from `mdb_cursor_init` when `mdb_page_search` fails, then checking that code in `mdb_put` before calling `mdb_cursor_put`.

That's what this patch does, and it works so far in my testing of lmdb-rs and kvstore. I haven't yet tried the rkv tests, nor tests for other components in Firefox. But I thought I'd open a PR for it to get early feedback from you.

(I also have a version of the patch that makes all `mdb_cursor_init` callers respect the result of that function, but that patch is failing a kvstore test with `MDB_NOTFOUND`; so clearly it's ok for `mdb_page_search` to fail with `MDB_NOTFOUND` sometimes. I'd need to do more research to determine in which other callers to `mdb_cursor_init` it's appropriate to check its result code.)
